### PR TITLE
21 publish artefacts on maven central

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,8 +41,18 @@ jobs:
           java-version: '17'
           cache: 'maven'
 
+      - name: Setup GPG signing
+        run: |
+          echo "$GPG_PRIVATE_KEY" | gpg --batch --import
+          echo "allow-loopback-pinentry" >> ~/.gnupg/gpg-agent.conf
+          echo "pinentry-mode loopback" >> ~/.gnupg/gpg.conf
+          echo "use-agent" >> ~/.gnupg/gpg.conf
+          echo RELOADAGENT | gpg-connect-agent
+        env:
+          GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
+
       - name: Build artefact
-        run: ./mvnw $COMMON_MAVEN_ARGS --file pom.xml -Drevision=${{steps.metadata.outputs.current-version}} deploy
+        run: ./mvnw $COMMON_MAVEN_ARGS --file pom.xml -Drevision=${{steps.metadata.outputs.current-version}} -Dgpg.keyname=${{ secrets.GPG_KEY_ID }} -Dgpg.passphrase=${{ secrets.GPG_PASSPHRASE }} deploy
 
       - name: Tag
         uses: hole19/git-tag-action@master

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    if: ${{github.event.pull_request.merged == true}}
+    if: ${{ github.event.pull_request.merged == true }}
 
     steps:
       - name: Checkout
@@ -25,7 +25,7 @@ jobs:
         uses: radcortez/project-metadata-action@main
         id: metadata
         with:
-          github-token: ${{secrets.GITHUB_TOKEN}}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           metadata-file-path: '.github/project.yml'
           local-file: 'true'
 
@@ -40,6 +40,10 @@ jobs:
           distribution: 'temurin'
           java-version: '17'
           cache: 'maven'
+          # Setup Maven Central portal
+          server-id: central
+          server-username: ${{ secrets.MAVEN_USERNAME }}
+          server-password: ${{ secrets.MAVEN_PASSWORD }}
 
       - name: Setup GPG signing
         run: |
@@ -51,8 +55,8 @@ jobs:
         env:
           GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
 
-      - name: Build artefact
-        run: ./mvnw $COMMON_MAVEN_ARGS --file pom.xml -Drevision=${{steps.metadata.outputs.current-version}} -Dgpg.keyname=${{ secrets.GPG_KEY_ID }} -Dgpg.passphrase=${{ secrets.GPG_PASSPHRASE }} deploy
+      - name: Build, sign & publish artefact
+        run: ./mvnw $COMMON_MAVEN_ARGS --file pom.xml -Drevision=${{ steps.metadata.outputs.current-version }} -Dgpg.keyname=${{ secrets.GPG_KEY_ID }} -Dgpg.passphrase=${{ secrets.GPG_PASSPHRASE }} deploy
 
       - name: Tag
         uses: hole19/git-tag-action@master

--- a/execution-planner/pom.xml
+++ b/execution-planner/pom.xml
@@ -65,7 +65,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-gpg-plugin</artifactId>
-                <version>3.1.0</version>
+                <version>3.2.7</version>
                 <executions>
                     <execution>
                         <id>sign-artifacts</id>

--- a/execution-planner/pom.xml
+++ b/execution-planner/pom.xml
@@ -33,7 +33,6 @@
                     </annotationProcessorPaths>
                 </configuration>
             </plugin>
-
             <plugin>
                 <artifactId>maven-dependency-plugin</artifactId>
                 <executions>
@@ -63,7 +62,27 @@
                     </systemProperties>
                 </configuration>
             </plugin>
-
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-gpg-plugin</artifactId>
+                <version>3.1.0</version>
+                <executions>
+                    <execution>
+                        <id>sign-artifacts</id>
+                        <phase>deploy</phase>
+                        <goals>
+                            <goal>sign</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <gpgArguments>
+                        <!-- Required for GitHub actions -->
+                        <arg>--pinentry-mode</arg>
+                        <arg>loopback</arg>
+                    </gpgArguments>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 
@@ -123,6 +142,4 @@
             <scope>compile</scope>
         </dependency>
     </dependencies>
-
-
 </project>

--- a/execution-planner/pom.xml
+++ b/execution-planner/pom.xml
@@ -83,6 +83,17 @@
                     </gpgArguments>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.sonatype.central</groupId>
+                <artifactId>central-publishing-maven-plugin</artifactId>
+                <version>0.7.0</version>
+                <extensions>true</extensions>
+                <configuration>
+                    <publishingServerId>central</publishingServerId>
+                    <!-- Automatically publish -->
+<!--                    <autoPublish>true</autoPublish>-->
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 


### PR DESCRIPTION
Enable publishing to Maven Central (portal). As a prerequisite the release is signed using GPG.

Please do **NOT** merge to master before 
- The secrets have been added to Github
- The release plugin & settings have been verified


