### PR TITLE
Run light version of pipeline when md file is changed

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,13 +26,33 @@ on:
       - '.gitignore'
       - 'CODEOWNERS'
       - 'LICENSE'
-      - '*.md'
       - '*.adoc'
       - '*.txt'
       - '.all-contributorsrc'
 
 jobs:
+  check:
+    # Check if there are other than .md files changed, if so do run full pipeline
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Check for code changes
+        id: changes
+        run: |
+          git fetch origin ${{ github.base_ref }}
+          changes=$(git diff --name-only origin/${{ github.base_ref }} HEAD)
+          echo "Changed files: $changes"
+          if echo "$changes" | grep -vE '\.(md)$'; then
+            echo "::set-output name=code_changed::true"
+          else
+            echo "::set-output name=code_changed::false"
+          fi
+
   build:
+    needs: check
+    if: needs.check.outputs.code_changed == 'true'
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
## Description
Adds a job that checks changes, and marks build successful if it only contains .md file changes. 
## Type of Change
Please delete options that are not relevant
- [ x] Bug fix (non-breaking change which fixes an issue)

## Related Issues
PR's cannot be merged when only and .md file is changed.

## Checklist
- [ ] Formatted according to the  [CONTRIBUTING guidelines](https://github.com/carbonintensityio/scheduler/blob/main/CONTRIBUTING.md)
- [ ] Follows the [coding guidelines](https://github.com/carbonintensityio/scheduler/blob/main/CONTRIBUTING.md#coding-guidelines)
- [ ] Follows the [logging guidelines](https://github.com/carbonintensityio/scheduler/blob/main/CONTRIBUTING.md#logging-guidelines)
- [ ] Tests are added
- [ ] Build runs successfully

-------
