### PR TITLE
Implement AutoCloseable on schedulers

### DIFF
--- a/core/src/main/java/io/carbonintensity/scheduler/runtime/SimpleScheduler.java
+++ b/core/src/main/java/io/carbonintensity/scheduler/runtime/SimpleScheduler.java
@@ -93,13 +93,13 @@ import io.carbonintensity.scheduler.spi.JobInstrumenter;
  * The scheduler should be properly shut down to release resources:
  *
  * <pre>{@code
- * scheduler.stop();
+ * scheduler.close();
  * }</pre>
  * </p>
  *
  * @see Scheduler
  */
-public class SimpleScheduler implements Scheduler {
+public class SimpleScheduler implements Scheduler, AutoCloseable {
 
     private static final Logger log = LoggerFactory.getLogger(SimpleScheduler.class);
     // milliseconds
@@ -249,7 +249,25 @@ public class SimpleScheduler implements Scheduler {
         }
     }
 
+    /**
+     * Stops the scheduler gracefully by closing all resources and shutting down running tasks.
+     * <p>
+     * This method is marked as deprecated and is planned for removal in future versions.
+     * It internally invokes the {@code close()} method to handle the scheduler's shutdown
+     * process, ensuring proper cleanup of executors and other resources.
+     *
+     * @deprecated since version 0.8.3, as this functionality is now handled by the {@code close()} method.
+     */
+    @Deprecated(since = "0.8.3", forRemoval = true)
     public void stop() {
+        close();
+    }
+
+    /**
+     * Stops the scheduler gracefully by closing all resources and shutting down running tasks.
+     */
+    @Override
+    public void close() {
         log.info("Shutting down simple scheduler gracefully.");
         if (scheduledFuture != null) {
             scheduledFuture.cancel(false);

--- a/core/src/test/java/io/carbonintensity/scheduler/TestDefaultCarbonIntensityProgrammatic.java
+++ b/core/src/test/java/io/carbonintensity/scheduler/TestDefaultCarbonIntensityProgrammatic.java
@@ -35,7 +35,7 @@ class TestDefaultCarbonIntensityProgrammatic {
 
     @AfterEach
     public void afterEach() {
-        scheduler.stop();
+        scheduler.close();
     }
 
     @Test

--- a/core/src/test/java/io/carbonintensity/scheduler/TestFallbackProgrammatic.java
+++ b/core/src/test/java/io/carbonintensity/scheduler/TestFallbackProgrammatic.java
@@ -35,7 +35,7 @@ class TestFallbackProgrammatic {
 
     @AfterEach
     public void afterEach() {
-        scheduler.stop();
+        scheduler.close();
     }
 
     @Test

--- a/core/src/test/java/io/carbonintensity/scheduler/TestFixedWindowScheduler.java
+++ b/core/src/test/java/io/carbonintensity/scheduler/TestFixedWindowScheduler.java
@@ -55,7 +55,7 @@ class TestFixedWindowScheduler {
     @AfterEach
     public void afterEach() {
         if (scheduler != null) {
-            scheduler.stop();
+            scheduler.close();
         }
     }
 

--- a/core/src/test/java/io/carbonintensity/scheduler/TestSuccessiveWindowScheduler.java
+++ b/core/src/test/java/io/carbonintensity/scheduler/TestSuccessiveWindowScheduler.java
@@ -52,7 +52,7 @@ class TestSuccessiveWindowScheduler {
     @AfterEach
     public void afterEach() {
         if (scheduler != null) {
-            scheduler.stop();
+            scheduler.close();
         }
     }
 

--- a/extensions/quarkus/runtime/src/main/java/io/carbonintensity/scheduler/quarkus/runtime/QuarkusScheduler.java
+++ b/extensions/quarkus/runtime/src/main/java/io/carbonintensity/scheduler/quarkus/runtime/QuarkusScheduler.java
@@ -21,7 +21,7 @@ import io.quarkus.runtime.Startup;
 
 @Singleton
 @Startup
-public class QuarkusScheduler {
+public class QuarkusScheduler implements AutoCloseable {
 
     private static final Logger LOG = Logger.getLogger(QuarkusScheduler.class);
 
@@ -44,9 +44,10 @@ public class QuarkusScheduler {
     }
 
     @PreDestroy
-    void stop() {
-        LOG.info("Stopping Green Scheduler");
-        greenScheduler.stop();
+    @Override
+    public void close() {
+        LOG.info("Closing Green Scheduler");
+        greenScheduler.close();
     }
 
     GreenScheduled lookupConfiguration(GreenScheduled scheduled) {

--- a/extensions/spring-boot-starter/src/main/java/io/carbonintensity/scheduler/spring/GreenSchedulerAutoConfiguration.java
+++ b/extensions/spring-boot-starter/src/main/java/io/carbonintensity/scheduler/spring/GreenSchedulerAutoConfiguration.java
@@ -95,10 +95,10 @@ public class GreenSchedulerAutoConfiguration {
     }
 
     @PreDestroy
-    public void stopScheduler() {
+    public void closeScheduler() {
         if (simpleScheduler != null) {
-            logger.info("Stopping the green scheduler.");
-            simpleScheduler.stop();
+            logger.info("Closing the green scheduler.");
+            simpleScheduler.close();
         }
     }
 }


### PR DESCRIPTION
## Description
This change implements `java.lang.AutoCloseable`. You are already following the principle as stated in its Javadoc, only with your own `stop` implementation:

> An object that may hold resources (such as file or socket handles) until it is closed.


## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist
- [x] Formatted according to the  [CONTRIBUTING guidelines](https://github.com/carbonintensityio/scheduler/blob/main/CONTRIBUTING.md)
- [x] Follows the [coding guidelines](https://github.com/carbonintensityio/scheduler/blob/main/CONTRIBUTING.md#coding-guidelines)
- [x] Follows the [logging guidelines](https://github.com/carbonintensityio/scheduler/blob/main/CONTRIBUTING.md#logging-guidelines)
~~- [ ] Tests are added~~
- [x] Build runs successfully

-------
